### PR TITLE
fix on Linux: Error 71 (Protocol error) dispatching to Wayland display

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm lint-staged
+pnpm lint-staged || bun lint-staged

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,13 @@ fn read_mp3_file(path: String) -> Result<String, String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // 在 Linux 上禁用 DMA-BUF 渲染器
+    // 否则无法在 Linux 上运行
+    // 相同的bug: https://github.com/tauri-apps/tauri/issues/10702
+    // 解决方案来源: https://github.com/clash-verge-rev/clash-verge-rev/blob/ae5b2cfb79423c7e76a281725209b812774367fa/src-tauri/src/lib.rs#L27-L28
+    #[cfg(target_os = "linux")]
+    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .setup(|app| {


### PR DESCRIPTION
在 Linux 上 `cargo tauri dev` 会出现： Error 71 (Protocol error) dispatching to Wayland display; 
然后异常退出。

在 Linux 上禁用 DMA-BUF 渲染器; 

[其他项目的相同issue](https://github.com/tauri-apps/tauri/issues/10702); 

[牛逼项目的解决方法](https://github.com/clash-verge-rev/clash-verge-rev/blob/ae5b2cfb79423c7e76a281725209b812774367fa/src-tauri/src/lib.rs#L27-L28);

PS：我不想装 nodejs， 直接用的 `bun`，但是由于 commit 检查，我小小改了一下 `.husky/pre-commit`