### PR TITLE
fix: 修复Ai菜单不能正确关闭的问题

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -218,6 +218,7 @@ export default function App() {
       onClick={() => {
         setIsMenuOpen(false);
         setIsStartFilePanelOpen(false);
+        setIsAiPanelOpen(false);
       }}
       onContextMenu={(e) => e.preventDefault()}
     >


### PR DESCRIPTION
通过调用 setIsAiPanelOpen(false) 来确保 AI 面板在`失去焦点`时被隐藏