### PR TITLE
fix: 修复鼠标拖出窗口后触发上下文菜单的问题

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -86,6 +86,17 @@ export default function App() {
           });
       }
     });
+    // 修复鼠标拖出窗口后触发上下文菜单的问题
+    window.addEventListener("contextmenu", (event) => {
+      console.log(event, window.screen);
+      if (
+        event.clientX < 0 ||
+        event.clientX > window.innerWidth ||
+        event.clientY < 0 ||
+        event.clientY > window.innerHeight
+      )
+        event.preventDefault();
+    });
     Settings.get("useNativeTitleBar").then((useNativeTitleBar) => {
       setUseNativeTitleBar(useNativeTitleBar);
       if (useNativeTitleBar) {


### PR DESCRIPTION
#204 
## 修复方法
通过监听 contextmenu 事件并检查鼠标位置是否在窗口内来实现修复

## 其它
代码放置位置可能不是特别好，但是也找不太到更好的位置了😣