### PR TITLE
fix: 修复空项目仍提示保存的问题

### DIFF
--- a/src/core/stage/stageManager/StageManager.tsx
+++ b/src/core/stage/stageManager/StageManager.tsx
@@ -64,6 +64,9 @@ export namespace StageManager {
     });
   }
 
+  export function isEmpty(): boolean {
+    return entities.length === 0;
+  }
   export function getTextNodes(): TextNode[] {
     return entities.valuesToArray().filter((node) => node instanceof TextNode);
   }

--- a/src/pages/_app_menu.tsx
+++ b/src/pages/_app_menu.tsx
@@ -69,7 +69,7 @@ export default function AppMenu({
    * 新建草稿
    */
   const onNewDraft = () => {
-    if (StageSaveManager.isSaved()) {
+    if (StageSaveManager.isSaved() || StageManager.isEmpty()) {
       StageManager.destroy();
       setFile("Project Graph");
     } else {
@@ -99,36 +99,42 @@ export default function AppMenu({
   };
 
   const onOpen = async () => {
-    if (Stage.Path.isDraft() && !StageSaveManager.isSaved()) {
-      Dialog.show({
-        title: "草稿未保存",
-        content: "当前草稿未保存，是否保存？",
-        buttons: [
-          { text: "我再想想" },
-          { text: "保存草稿", onClick: onSave },
-          {
-            text: "丢弃并打开新文件",
-            onClick: () => {
-              StageManager.destroy();
-              openFileByDialogWindow();
+    if (!StageSaveManager.isSaved()) {
+      if (StageManager.isEmpty()) {
+        //空项目不需要保存
+        StageManager.destroy();
+        openFileByDialogWindow();
+      } else if (Stage.Path.isDraft()) {
+        Dialog.show({
+          title: "草稿未保存",
+          content: "当前草稿未保存，是否保存？",
+          buttons: [
+            { text: "我再想想" },
+            { text: "保存草稿", onClick: onSave },
+            {
+              text: "丢弃并打开新文件",
+              onClick: () => {
+                StageManager.destroy();
+                openFileByDialogWindow();
+              },
             },
-          },
-        ],
-      });
-    } else if (!StageSaveManager.isSaved()) {
-      Dialog.show({
-        title: "未保存",
-        content: "是否保存当前文件？",
-        buttons: [
-          {
-            text: "保存并打开新文件",
-            onClick: () => {
-              onSave().then(openFileByDialogWindow);
+          ],
+        });
+      } else {
+        Dialog.show({
+          title: "未保存",
+          content: "是否保存当前文件？",
+          buttons: [
+            {
+              text: "保存并打开新文件",
+              onClick: () => {
+                onSave().then(openFileByDialogWindow);
+              },
             },
-          },
-          { text: "我再想想" },
-        ],
-      });
+            { text: "我再想想" },
+          ],
+        });
+      }
     } else {
       // 直接打开文件
       openFileByDialogWindow();

--- a/src/pages/_start_file_panel.tsx
+++ b/src/pages/_start_file_panel.tsx
@@ -19,6 +19,7 @@ import Switch from "../components/ui/Switch";
 import { RecentFileManager } from "../core/service/RecentFileManager";
 import { StartFilesManager } from "../core/service/StartFilesManager";
 import { StageSaveManager } from "../core/stage/StageSaveManager";
+import { StageManager } from "../core/stage/stageManager/StageManager";
 import { fileAtom } from "../state";
 import { cn } from "../utils/cn";
 import { Dialog } from "../utils/dialog";
@@ -123,7 +124,9 @@ export default function StartFilePanel({ open = false }: { open: boolean }) {
   };
   const onLoadCurrentStartFile = (path: string) => {
     return function () {
-      if (currentFile === "Project Graph") {
+      if (StageManager.isEmpty()) {
+        checkoutFile(path);
+      } else if (currentFile === "Project Graph") {
         Dialog.show({
           title: "真的要切换吗？",
           content: "您现在的新建草稿没有保存，是否要切换项目？",


### PR DESCRIPTION
#255 
## 修复方法
- 在 StageManager 中添加 isEmpty 函数，用于判断当前项目是否为空
- 修改 AppMenu 组件中的新建草稿和打开文件逻辑，增加对空项目的处理
- 更新 StartFilePanel 组件中的文件加载逻辑，考虑空项目情况