### PR TITLE
fix: 修复android无法载入程序的问题

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -38,7 +38,7 @@ import "./polyfills/roundRect";
 import { Dialog } from "./utils/dialog";
 import { exists } from "./utils/fs";
 import { exit, openDevtools, writeStderr, writeStdout } from "./utils/otherApi";
-import { getCurrentWindow, isDesktop, isWeb } from "./utils/platform";
+import { getCurrentWindow, isDesktop, isMobile, isWeb } from "./utils/platform";
 import { Popup } from "./utils/popup";
 import { InputElement } from "./core/render/domElement/inputElement";
 
@@ -50,7 +50,7 @@ const el = document.getElementById("root")!;
 // 在这里看着清爽一些，像一个列表清单一样。也方便调整顺序
 
 (async () => {
-  const matches = !isWeb ? await getMatches() : null;
+  const matches = !isWeb && !isMobile ? await getMatches() : null;
   const isCliMode = isDesktop && matches?.args.output?.occurrences === 1;
   await Promise.all([
     Settings.init(),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -38,7 +38,7 @@ import "./polyfills/roundRect";
 import { Dialog } from "./utils/dialog";
 import { exists } from "./utils/fs";
 import { exit, openDevtools, writeStderr, writeStdout } from "./utils/otherApi";
-import { getCurrentWindow, isDesktop, isMobile, isWeb } from "./utils/platform";
+import { getCurrentWindow, isDesktop, isWeb } from "./utils/platform";
 import { Popup } from "./utils/popup";
 import { InputElement } from "./core/render/domElement/inputElement";
 
@@ -50,7 +50,7 @@ const el = document.getElementById("root")!;
 // 在这里看着清爽一些，像一个列表清单一样。也方便调整顺序
 
 (async () => {
-  const matches = !isWeb && !isMobile ? await getMatches() : null;
+  const matches = !isWeb && isDesktop ? await getMatches() : null;
   const isCliMode = isDesktop && matches?.args.output?.occurrences === 1;
   await Promise.all([
     Settings.init(),


### PR DESCRIPTION
#267 
## 问题原因
主函数中调用了不支持android的`@tauri-apps/plugin-cli`插件
## 解决方法
- 修改主逻辑，仅在非 Web 且非移动设备环境下执行 getMatches()