### PR TITLE
fix: 修复连接到编辑状态节点时会受到浏览器菜单影响的问题

### DIFF
--- a/src/core/service/controller/Controller.tsx
+++ b/src/core/service/controller/Controller.tsx
@@ -177,6 +177,14 @@ export namespace Controller {
     const pressWorldLocation = Renderer.transformView2World(new Vector(x, y));
     // 获取左右中键
     lastMousePressLocation[button] = pressWorldLocation;
+
+    // 左右键按下时移除所有input焦点
+    if (button === 0 || button === 2) {
+      const activeElement = document.activeElement as HTMLElement;
+      if (activeElement && activeElement.blur) {
+        activeElement.blur();
+      }
+    }
   }
 
   function handleMouseup(button: number, x: number, y: number) {


### PR DESCRIPTION
#269 
## 问题原因
右键拖动至正在输入的input时会优先触发input的浏览器菜单
## 解决办法
在左右键按下时获取当前焦点元素并调用其 blur 方法来实现焦点移除