### PR TITLE
fix(dialog): 修复弹出对话框时无法移动窗口的问题

### DIFF
--- a/src/utils/dialog.tsx
+++ b/src/utils/dialog.tsx
@@ -52,6 +52,20 @@ export namespace Dialog {
       );
     });
   }
+  export function BackDrop() {
+    return (
+      <div
+        data-tauri-drag-region
+        className={cn(
+          "hover:cursor-move active:scale-100 active:cursor-grabbing",
+          "fixed left-0 top-0 z-[100] h-full w-full bg-black/0 backdrop-blur-0",
+          {
+            "bg-black/70 !backdrop-blur-lg": show,
+          },
+        )}
+      ></div>
+    );
+  }
 
   function Component({
     title = "",
@@ -141,14 +155,7 @@ export namespace Dialog {
             ))}
           </div>
         </div>
-        <div
-          className={cn(
-            "fixed left-0 top-0 z-[100] h-full w-full bg-black/0 backdrop-blur-0",
-            {
-              "bg-black/70 !backdrop-blur-lg": show,
-            },
-          )}
-        ></div>
+        <BackDrop />
       </>
     );
   }


### PR DESCRIPTION
## 问题原因
对话框的遮蔽层盖过了模拟标题栏

## 解决办法
将遮蔽层设置为可拖拽窗口部分

感谢群友：诶嘿
![image](https://github.com/user-attachments/assets/4a90450b-1ecd-41d2-bf92-36800e2f5ad2)
