### PR TITLE
修订部分错别字

### DIFF
--- a/app/src/core/render/canvas2d/renderer.tsx
+++ b/app/src/core/render/canvas2d/renderer.tsx
@@ -829,7 +829,7 @@ export namespace Renderer {
         Controller.pressingKeySet.has("d"))
     ) {
       TextRenderer.renderOneLineText(
-        "      方向键移动视野被禁止，可通过快捷键松或设置界面送开“手刹”",
+        "      方向键移动视野被禁止，可通过快捷键或设置界面松开“手刹”",
         new Vector(margin, Renderer.h - 60),
         15,
         StageStyleManager.currentStyle.effects.flash,

--- a/app/src/locales/zh_CN.yml
+++ b/app/src/locales/zh_CN.yml
@@ -367,7 +367,7 @@ settings:
   doubleClickMiddleMouseButton:
     title: 双击中键鼠标
     description: |
-      将滚轮键快速按下两次时执行的操作。默认时重置视野。
+      将滚轮键快速按下两次时执行的操作。默认是重置视野。
       关闭此选项，可以防止误触发。
     options:
       adjustCamera: 调整视野


### PR DESCRIPTION
## 中文设置界面

`将滚轮键快速按下两次时执行的操作。默认时重置视野。`，`默认时`→`默认是`

很小一个修改（只动了一个字），参考了`deleteSelectedStageObjects`小节的`默认是delete键，您可以改成backspace键`

## 手刹状态WASD键提示

`方向键移动视野被禁止，可通过快捷键松或设置界面送开“手刹”`→`方向键移动视野被禁止，可通过快捷键或设置界面松开“手刹”`

让句子更通顺了些，它在初次下载使用时容易遇到

另外，这句子似乎是硬编码的，部分UI后续还可继续做i18n：
![image](https://github.com/user-attachments/assets/fb0d0301-674f-4f3c-b5c1-d2d59f457cbc)
