### PR TITLE
🐛 选中文字点到窗口外就会看不见，点一下窗口就又看见了

### DIFF
--- a/app/src/core/stage/stageObject/entity/Section.tsx
+++ b/app/src/core/stage/stageObject/entity/Section.tsx
@@ -15,6 +15,7 @@ import { ConnectableEntity } from "../abstract/ConnectableEntity";
 import { Entity } from "../abstract/StageEntity";
 import { CollisionBox } from "../collisionBox/collisionBox";
 import { SectionMethods } from "../../stageManager/basicMethods/SectionMethods";
+import { SectionRenderer } from "../../../render/canvas2d/entityRenderer/section/SectionRenderer";
 
 export class Section extends ConnectableEntity {
   /**
@@ -22,9 +23,17 @@ export class Section extends ConnectableEntity {
    */
   _isSelected: boolean = false;
   public uuid: string;
-  public isEditingTitle: boolean = false;
+  _isEditingTitle: boolean = false;
   private _collisionBoxWhenCollapsed: CollisionBox;
   private _collisionBoxNormal: CollisionBox;
+
+  public get isEditingTitle() {
+    return this._isEditingTitle;
+  }
+  public set isEditingTitle(value: boolean) {
+    this._isEditingTitle = value;
+    SectionRenderer.render(this);
+  }
 
   /**
    * 小于多少的情况下，开始渲染大标题

--- a/app/src/core/stage/stageObject/entity/TextNode.tsx
+++ b/app/src/core/stage/stageObject/entity/TextNode.tsx
@@ -15,6 +15,7 @@ import { Entity } from "../abstract/StageEntity";
 import { ResizeAble } from "../abstract/StageObjectInterface";
 import { CollisionBox } from "../collisionBox/collisionBox";
 import { Section } from "./Section";
+import { TextNodeRenderer } from "../../../render/canvas2d/entityRenderer/textNode/TextNodeRenderer";
 
 /**
  *
@@ -72,8 +73,17 @@ export class TextNode extends ConnectableEntity implements ResizeAble {
   /**
    * 是否在编辑文字，编辑时不渲染文字
    */
-  isEditing: boolean = false;
+  _isEditing: boolean = false;
 
+  public get isEditing() {
+    return this._isEditing;
+  }
+
+  public set isEditing(value: boolean) {
+    this._isEditing = value;
+    TextNodeRenderer.renderTextNode(this);
+    // 再主动渲染一次，确保即使渲染引擎停止，文字也能显示出来
+  }
   isHiddenBySectionCollapse = false;
 
   color: Color = Color.Transparent;

--- a/app/src/core/stage/stageObject/entity/UrlNode.tsx
+++ b/app/src/core/stage/stageObject/entity/UrlNode.tsx
@@ -9,6 +9,7 @@ import { NodeMoveShadowEffect } from "../../../service/feedbackService/effectEng
 import { Stage } from "../../Stage";
 import { ConnectableEntity } from "../abstract/ConnectableEntity";
 import { CollisionBox } from "../collisionBox/collisionBox";
+import { UrlNodeRenderer } from "../../../render/canvas2d/entityRenderer/urlNode/urlNodeRenderer";
 
 /**
  * 网页链接节点
@@ -28,12 +29,19 @@ export class UrlNode extends ConnectableEntity {
   /** 上半部分的高度 */
   static titleHeight: number = 100;
   /** 是否正在编辑标题 */
-  isEditingTitle: boolean = false;
+  _isEditingTitle: boolean = false;
   /** 鼠标是否悬浮在标题上 */
   isMouseHoverTitle: boolean = false;
   /** 鼠标是否悬浮在url上 */
   isMouseHoverUrl: boolean = false;
 
+  public get isEditingTitle() {
+    return this._isEditingTitle;
+  }
+  public set isEditingTitle(value: boolean) {
+    this._isEditingTitle = value;
+    UrlNodeRenderer.render(this);
+  }
   get geometryCenter(): Vector {
     return this.collisionBox.getRectangle().center;
   }


### PR DESCRIPTION
- 当点到窗口外时，会多渲染一次文字，确保文字显示
- 文字节点、Section标题、Url节点标题，都修复了
- fix Issue: #346