### PR TITLE
fix: 修复 Section 移动时速度叠加的问题

### DIFF
--- a/app/src/core/stage/stageManager/concreteMethods/StageSectionInOutManager.tsx
+++ b/app/src/core/stage/stageManager/concreteMethods/StageSectionInOutManager.tsx
@@ -90,6 +90,11 @@ export class SectionInOutManager {
     // 获取section的父级section
     const fatherSections = this.project.sectionMethods.getFatherSections(section);
 
+    // 先从父 section 的 children 中移除旧的 section 引用（直接操作数组，避免触发 sectionDropChild 的连锁反应）
+    for (const fatherSection of fatherSections) {
+      fatherSection.children = fatherSection.children.filter((child) => child.uuid !== section.uuid);
+    }
+
     // 创建新的TextNode，保持UUID不变
     const textNode = new TextNode(this.project, {
       uuid: section.uuid, // 保持UUID不变

--- a/app/src/core/stage/stageObject/entity/Section.tsx
+++ b/app/src/core/stage/stageObject/entity/Section.tsx
@@ -228,6 +228,10 @@ export class Section extends ConnectableEntity {
     }
     // 让内部元素也移动
     for (const child of this.children) {
+      // 跳过已被选中的子元素，避免重复移动（解决速度叠加bug）
+      if (child.isSelected) {
+        continue;
+      }
       child.move(delta);
     }
 


### PR DESCRIPTION
## 修复两个 Section 移动时速度叠加的 bug：
#### Bug 1: 选中 Section 并选中内部节点时，拖动移动速度加倍 https://github.com/graphif/project-graph/issues/361
- **复现步骤**：选中一个 Section，同时选中其内部的节点，然后拖动移动
- **原因**：`Section.move()` 会遍历所有子节点并调用 `child.move()`，但已被选中的子节点也会被 `moveSelectedEntities()` 单独移动，导致移动两次
#### Bug 2: 嵌套 Section 移除子节点后，拖动父级 Section 导致速度加倍
- **复现步骤**：创建 Section1 → Section2 → Section3 嵌套结构，将 Section3 从 Section2 中 jump 出去，然后拖动 Section1
- **原因**：`convertSectionToTextNode()` 中，先添加新的 TextNode 到父 Section，再删除旧 Section，但旧 Section 的引用仍在 `children` 数组中。`updateReferences()` 根据 UUID 查找时，由于新旧对象 UUID 相同，导致 TextNode 被添加两次到 `children` 数组
### 修复方案
#### 1. **Bug 1**：在 `Section.move()` 中跳过已被选中的子元素
#### 2. **Bug 2**：在 `convertSectionToTextNode()` 中，先从父 Section 的 children 数组移除旧引用，再添加新的 TextNode
### 修复前后对比
---
 修复前

https://github.com/user-attachments/assets/3c0630f2-b35d-4ab7-a716-ea33c058ba97
 
修复后

https://github.com/user-attachments/assets/8df2d7e9-c8f5-44e8-acf0-b3adfa0220d6


