### PR TITLE
feat: markdown导入后自动调用右向树布局

### DIFF
--- a/app/src/core/service/dataGenerateService/stageImportEngine/MarkdownImporter.tsx
+++ b/app/src/core/service/dataGenerateService/stageImportEngine/MarkdownImporter.tsx
@@ -23,8 +23,9 @@ export class MarkdownImporter extends BaseImporter {
    * 导入 Markdown 文本并生成节点树
    * @param markdownText Markdown 格式文本
    * @param diffLocation 偏移位置
+   * @param autoLayout 是否自动应用树形布局（默认为 true，自动整理为向右的树状结构）
    */
-  public import(markdownText: string, diffLocation: Vector = Vector.getZero()): void {
+  public import(markdownText: string, diffLocation: Vector = Vector.getZero(), autoLayout = true): void {
     const markdownJson = parseMarkdownToJSON(markdownText);
 
     const monoStack = new MonoStack<TextNode>();
@@ -75,6 +76,11 @@ export class MarkdownImporter extends BaseImporter {
     // 遍历所有根节点
     for (const markdownNode of markdownJson) {
       dfsMarkdownNode(markdownNode, 0);
+    }
+
+    // 自动应用树形布局（如果启用）
+    if (autoLayout) {
+      this.project.autoAlign.autoLayoutSelectedFastTreeMode(rootNode);
     }
 
     // 记录历史

--- a/app/src/core/service/dataGenerateService/stageImportEngine/stageImportEngine.tsx
+++ b/app/src/core/service/dataGenerateService/stageImportEngine/stageImportEngine.tsx
@@ -66,13 +66,14 @@ export class StageImport {
    * 支持 Markdown 标题层级（#, ##, ###）
    * @param markdownText Markdown 格式文本
    * @param diffLocation 偏移位置
+   * @param autoLayout 是否自动应用树形布局（默认为 true）
    * @example
    * # 标题1
    * ## 子标题1.1
    * ## 子标题1.2
    * # 标题2
    */
-  public addNodeByMarkdown(markdownText: string, diffLocation: Vector = Vector.getZero()) {
-    return this.markdownImporter.import(markdownText, diffLocation);
+  public addNodeByMarkdown(markdownText: string, diffLocation: Vector = Vector.getZero(), autoLayout = true) {
+    return this.markdownImporter.import(markdownText, diffLocation, autoLayout);
   }
 }

--- a/app/src/core/stage/stageManager/StageManager.tsx
+++ b/app/src/core/stage/stageManager/StageManager.tsx
@@ -621,8 +621,8 @@ export class StageManager {
     }
   }
 
-  generateNodeByMarkdown(text: string, location = this.project.camera.location) {
-    this.project.nodeAdder.addNodeByMarkdown(text, location);
+  generateNodeByMarkdown(text: string, location = this.project.camera.location, autoLayout = true) {
+    this.project.nodeAdder.addNodeByMarkdown(text, location, autoLayout);
     this.project.historyManager.recordStep();
   }
 

--- a/app/src/core/stage/stageManager/concreteMethods/StageNodeAdder.tsx
+++ b/app/src/core/stage/stageManager/concreteMethods/StageNodeAdder.tsx
@@ -208,8 +208,14 @@ export class NodeAdder {
     this.project.stageImport.addNodeMermaidByText(text, diffLocation);
   }
 
-  public addNodeByMarkdown(markdownText: string, diffLocation: Vector = Vector.getZero()) {
-    this.project.stageImport.addNodeByMarkdown(markdownText, diffLocation);
+  /**
+   * 根据 Markdown 文本生成节点树结构
+   * @param markdownText Markdown 格式文本
+   * @param diffLocation 偏移位置
+   * @param autoLayout 是否自动应用树形布局（默认为 true）
+   */
+  public addNodeByMarkdown(markdownText: string, diffLocation: Vector = Vector.getZero(), autoLayout = true) {
+    this.project.stageImport.addNodeByMarkdown(markdownText, diffLocation, autoLayout);
   }
 
   /***


### PR DESCRIPTION
## 实现方案

在 Markdown 导入链路的末端（节点和边全部创建完成后、记录历史之前），对根节点调用已有的 `autoLayoutSelectedFastTreeMode` 方法。

### 调用链路

```
GenerateNodeWindow (UI)
  → StageManager.generateNodeByMarkdown(text, location, autoLayout)
    → NodeAdder.addNodeByMarkdown(markdownText, diffLocation, autoLayout)
      → StageImport.addNodeByMarkdown(markdownText, diffLocation, autoLayout)
        → MarkdownImporter.import(markdownText, diffLocation, autoLayout)
          → autoAlign.autoLayoutSelectedFastTreeMode(rootNode)  // ← 新增
```

### 关键设计决策

- **仅对根节点调用布局**：`autoLayoutSelectedFastTreeMode` 会递归处理整棵子树，只需传入 root 即可
- **默认启用，可选关闭**：`autoLayout` 参数默认为 `true`，保持向后兼容，调用方可传 `false` 跳过自动布局
- **布局在历史记录之前执行**：确保 undo 时能一步撤销「导入+布局」的完整操作
- **复用已有算法**：直接使用 `StageAutoAlignManager` 中的快速树布局，与右键菜单「自动排列 → 向右树形」完全一致

## 效果

https://github.com/user-attachments/assets/437834cb-3a1a-4883-8b75-2e2ff298f231

